### PR TITLE
Unify CLI bootstrap args and improve test isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ python urbantrips/run_all_urbantrips.py --borrar_corrida all
 
 ```bash
 streamlit run urbantrips/dashboard/dashboard.py
+streamlit run urbantrips/dashboard/dashboard.py -- --base-dir /runs/city_A
+    → Usa un directorio base específico (útil junto a corridas aisladas con --base-dir)
 ```
 
 ---

--- a/README_en.md
+++ b/README_en.md
@@ -338,6 +338,8 @@ python urbantrips/run_all_urbantrips.py --borrar_corrida all
 
 ```bash
 streamlit run urbantrips/dashboard/dashboard.py
+streamlit run urbantrips/dashboard/dashboard.py -- --base-dir /runs/city_A
+    → Uses a specific base directory (useful alongside isolated runs via --base-dir)
 ```
 
 ---

--- a/docs/superpowers/specs/2026-07-02-unify-cli-bootstrap-args-design.md
+++ b/docs/superpowers/specs/2026-07-02-unify-cli-bootstrap-args-design.md
@@ -1,0 +1,79 @@
+# Unify CLI bootstrap arguments
+
+**Date:** 2026-07-02
+**Status:** approved
+
+## Goal
+
+`run_all_urbantrips.py` and `dashboard.py` are the only two script entry points in the repo. Both need `--config` and `--base-dir` to resolve paths, but today they implement this independently: `run_all_urbantrips.py` uses `argparse` with `-c/--config` and `-d/--base-dir`; `dashboard.py` hand-scans `sys.argv` for `--config` only, with no `--base-dir` support and no short flag. Unify them so both scripts accept the same bootstrap flags, defined once.
+
+## Approach
+
+Extract the two bootstrap flags (`-c/--config`, `-d/--base-dir`) into a small shared module. Each script keeps its own `ArgumentParser` (they have different additional flags — `-b`, `-n`, `--step`, `--through` are run_all-only and don't apply to viewing a dashboard), but both call into the shared module to define and apply the common ones. This avoids a second, divergent copy of the flag definitions and env var wiring.
+
+## Architecture
+
+### New module: `urbantrips/utils/cli.py`
+
+```python
+def add_bootstrap_args(parser: argparse.ArgumentParser) -> None:
+    """Add -c/--config and -d/--base-dir to an existing parser."""
+
+def apply_bootstrap_env(args: argparse.Namespace) -> None:
+    """Set URBANTRIPS_CONFIG / URBANTRIPS_BASE env vars from parsed args, if present."""
+```
+
+- `add_bootstrap_args` adds exactly the two `add_argument` calls currently inlined in `run_all_urbantrips.build_parser()` (same flags, `dest`, `help` text).
+- `apply_bootstrap_env` replaces the two `if args.config: os.environ[...]` / `if args.base_dir: os.environ[...]` lines currently duplicated inline.
+
+## Components
+
+### Modified
+
+| File | Change |
+|---|---|
+| `urbantrips/run_all_urbantrips.py` | `build_parser()` calls `add_bootstrap_args(parser)` instead of inlining `-c`/`-d`; `__main__` calls `apply_bootstrap_env(args)` instead of the manual env var sets |
+| `urbantrips/dashboard/dashboard.py` | Replace the manual `sys.argv` scan (module top, before `import streamlit`) with: build an `argparse.ArgumentParser`, `add_bootstrap_args(parser)`, `args, _ = parser.parse_known_args()`, `apply_bootstrap_env(args)`. Update the module comment to document `--base-dir` alongside `--config`. |
+
+### New
+
+**`urbantrips/utils/cli.py`** — `add_bootstrap_args()`, `apply_bootstrap_env()`.
+
+## Data flow
+
+```
+run_all_urbantrips.py __main__:
+  build_parser() → add_bootstrap_args(parser)   # adds -c/-d
+  parser.parse_args()
+  apply_bootstrap_env(args)                      # sets URBANTRIPS_CONFIG / URBANTRIPS_BASE
+  init_paths(...)                                # unchanged, explicit
+
+dashboard.py (module top-level, before importing streamlit):
+  argparse.ArgumentParser() → add_bootstrap_args(parser)
+  parser.parse_known_args()                      # tolerant of unexpected args
+  apply_bootstrap_env(args)                      # sets same env vars
+  # no explicit init_paths() call — get_paths() lazily reads URBANTRIPS_BASE/URBANTRIPS_CONFIG
+```
+
+`parse_known_args` is used in `dashboard.py` (not `parse_args`) defensively, in case Streamlit's invocation ever forwards something unexpected after `--`; `run_all_urbantrips.py` keeps `parse_args` since it's the sole consumer of its own argv.
+
+## Error handling
+
+No behavior change from today: invalid `--base-dir` still surfaces as `FileNotFoundError` from `init_paths()`/`get_paths()`, unrelated to this refactor. Unknown flags to `dashboard.py` are silently ignored via `parse_known_args`, matching today's silent-ignore behavior of the manual `sys.argv` scan.
+
+## Testing
+
+- New `tests/unit/test_cli.py`: `add_bootstrap_args` produces a parser accepting `-c/--config` and `-d/--base-dir`; `apply_bootstrap_env` sets the right env vars (and doesn't set them when args are `None`).
+- `tests/unit/test_cli_entrypoint.py`: existing tests continue to pass unchanged (parser behavior for `-c`/`-d` is identical, just sourced from the shared helper).
+- `dashboard.py`'s argv-parsing block stays a few lines at the top of the file (before `import streamlit`), calling straight into `add_bootstrap_args`/`apply_bootstrap_env` — no new function is introduced there. Since importing the rest of the file has Streamlit side effects, this block itself is covered indirectly by `test_cli.py`'s coverage of `add_bootstrap_args`/`apply_bootstrap_env`, and is otherwise validated manually per the design's usage examples (Streamlit isn't in the automated unit test surface today either).
+
+## Usage examples
+
+```bash
+# Before: only --config worked
+streamlit run urbantrips/dashboard/dashboard.py -- --config configs/otra_ciudad.yaml
+
+# After: --base-dir also works, plus the -c/-d short flags
+streamlit run urbantrips/dashboard/dashboard.py -- --base-dir /runs/city_A
+streamlit run urbantrips/dashboard/dashboard.py -- -c configs/otra_ciudad.yaml
+```

--- a/urbantrips/dashboard/dashboard.py
+++ b/urbantrips/dashboard/dashboard.py
@@ -1,13 +1,15 @@
+import argparse
 import sys
-import os
 
-# Propagate --config flag to all dashboard modules via env var.
+from urbantrips.utils.cli import add_bootstrap_args, apply_bootstrap_env
+
+# Propagate --config / --base-dir flags to all dashboard modules via env vars.
 # Usage: streamlit run dashboard.py -- --config /path/to/configuraciones_generales.yaml
-_argv = sys.argv[1:]
-if "--config" in _argv:
-    _idx = _argv.index("--config")
-    if _idx + 1 < len(_argv):
-        os.environ["URBANTRIPS_CONFIG"] = str(_argv[_idx + 1])
+# Usage: streamlit run dashboard.py -- --base-dir /path/to/run_dir
+_parser = argparse.ArgumentParser()
+add_bootstrap_args(_parser)
+_args, _ = _parser.parse_known_args(sys.argv[1:])
+apply_bootstrap_env(_args)
 
 import streamlit as st
 import pandas as pd

--- a/urbantrips/run_all_urbantrips.py
+++ b/urbantrips/run_all_urbantrips.py
@@ -11,6 +11,7 @@ from urbantrips.utils.run_process import (
     run_dashboard,
     run_all,
 )
+from urbantrips.utils.cli import add_bootstrap_args, apply_bootstrap_env
 
 """
 ────────────────────────────────────────────────────────────────────────────
@@ -80,22 +81,7 @@ def build_parser():
         description="Ejecuta corridas de UrbanTrips con opciones de borrado y dashboard."
     )
 
-    parser.add_argument(
-        "-c",
-        "--config",
-        type=str,
-        default=None,
-        help="Ruta al archivo de configuración YAML (por defecto: configs/configuraciones_generales.yaml)",
-    )
-
-    parser.add_argument(
-        "-d",
-        "--base-dir",
-        type=str,
-        default=None,
-        dest="base_dir",
-        help="Project root directory. Config, inputs, databases, and outputs are resolved relative to this path.",
-    )
+    add_bootstrap_args(parser)
 
     parser.add_argument(
         "-b",
@@ -144,7 +130,6 @@ if __name__ == "__main__":
         datefmt="%H:%M:%S",
     )
 
-    import os
     from pathlib import Path
     from urbantrips.utils.paths import init_paths
 
@@ -153,11 +138,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     _validate_args(args)
 
-    if args.config:
-        os.environ["URBANTRIPS_CONFIG"] = args.config
-
-    if args.base_dir:
-        os.environ["URBANTRIPS_BASE"] = args.base_dir
+    apply_bootstrap_env(args)
 
     init_paths(
         base_dir=Path(args.base_dir) if args.base_dir else None,

--- a/urbantrips/tests/unit/test_cli.py
+++ b/urbantrips/tests/unit/test_cli.py
@@ -1,0 +1,56 @@
+import argparse
+import os
+
+from urbantrips.utils.cli import add_bootstrap_args, apply_bootstrap_env
+
+
+def test_add_bootstrap_args_accepts_config_and_base_dir():
+    parser = argparse.ArgumentParser()
+    add_bootstrap_args(parser)
+
+    args = parser.parse_args(["--config", "configs/x.yaml", "--base-dir", "/tmp/city_a"])
+
+    assert args.config == "configs/x.yaml"
+    assert args.base_dir == "/tmp/city_a"
+
+
+def test_add_bootstrap_args_short_flags():
+    parser = argparse.ArgumentParser()
+    add_bootstrap_args(parser)
+
+    args = parser.parse_args(["-c", "configs/x.yaml", "-d", "/tmp/city_b"])
+
+    assert args.config == "configs/x.yaml"
+    assert args.base_dir == "/tmp/city_b"
+
+
+def test_add_bootstrap_args_defaults_to_none():
+    parser = argparse.ArgumentParser()
+    add_bootstrap_args(parser)
+
+    args = parser.parse_args([])
+
+    assert args.config is None
+    assert args.base_dir is None
+
+
+def test_apply_bootstrap_env_sets_both_vars(monkeypatch):
+    monkeypatch.delenv("URBANTRIPS_CONFIG", raising=False)
+    monkeypatch.delenv("URBANTRIPS_BASE", raising=False)
+
+    args = argparse.Namespace(config="configs/x.yaml", base_dir="/tmp/city_a")
+    apply_bootstrap_env(args)
+
+    assert os.environ["URBANTRIPS_CONFIG"] == "configs/x.yaml"
+    assert os.environ["URBANTRIPS_BASE"] == "/tmp/city_a"
+
+
+def test_apply_bootstrap_env_leaves_env_untouched_when_args_none(monkeypatch):
+    monkeypatch.delenv("URBANTRIPS_CONFIG", raising=False)
+    monkeypatch.delenv("URBANTRIPS_BASE", raising=False)
+
+    args = argparse.Namespace(config=None, base_dir=None)
+    apply_bootstrap_env(args)
+
+    assert "URBANTRIPS_CONFIG" not in os.environ
+    assert "URBANTRIPS_BASE" not in os.environ

--- a/urbantrips/tests/unit/test_cli.py
+++ b/urbantrips/tests/unit/test_cli.py
@@ -41,8 +41,12 @@ def test_apply_bootstrap_env_sets_both_vars(monkeypatch):
     args = argparse.Namespace(config="configs/x.yaml", base_dir="/tmp/city_a")
     apply_bootstrap_env(args)
 
-    assert os.environ["URBANTRIPS_CONFIG"] == "configs/x.yaml"
-    assert os.environ["URBANTRIPS_BASE"] == "/tmp/city_a"
+    try:
+        assert os.environ["URBANTRIPS_CONFIG"] == "configs/x.yaml"
+        assert os.environ["URBANTRIPS_BASE"] == "/tmp/city_a"
+    finally:
+        os.environ.pop("URBANTRIPS_CONFIG", None)
+        os.environ.pop("URBANTRIPS_BASE", None)
 
 
 def test_apply_bootstrap_env_leaves_env_untouched_when_args_none(monkeypatch):

--- a/urbantrips/utils/cli.py
+++ b/urbantrips/utils/cli.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+import os
+
+
+def add_bootstrap_args(parser: argparse.ArgumentParser) -> None:
+    """Add -c/--config and -d/--base-dir to an existing parser."""
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        default=None,
+        help="Ruta al archivo de configuración YAML (por defecto: configs/configuraciones_generales.yaml)",
+    )
+
+    parser.add_argument(
+        "-d",
+        "--base-dir",
+        type=str,
+        default=None,
+        dest="base_dir",
+        help="Project root directory. Config, inputs, databases, and outputs are resolved relative to this path.",
+    )
+
+
+def apply_bootstrap_env(args: argparse.Namespace) -> None:
+    """Set URBANTRIPS_CONFIG / URBANTRIPS_BASE env vars from parsed args, if present."""
+    if args.config:
+        os.environ["URBANTRIPS_CONFIG"] = args.config
+
+    if args.base_dir:
+        os.environ["URBANTRIPS_BASE"] = args.base_dir


### PR DESCRIPTION
This pull request unifies the handling of CLI bootstrap arguments (`--config` and `--base-dir`) for both `run_all_urbantrips.py` and `dashboard.py` scripts by introducing a shared utility module. This eliminates duplicated code, ensures consistent argument parsing, and improves maintainability. The update also adds comprehensive unit tests for the new shared logic and updates documentation and usage examples.

**Core CLI Refactor:**
* Introduced a new module `urbantrips/utils/cli.py` containing `add_bootstrap_args()` and `apply_bootstrap_env()` to centralize the definition and environment propagation of `-c/--config` and `-d/--base-dir` flags.
* Refactored `run_all_urbantrips.py` and `dashboard.py` to use the shared CLI helpers, removing manual argument parsing and environment variable setting for these flags. [[1]](diffhunk://#diff-3295dc7dde885bb67176d1514b95de33527c6cdf6c2050de8c3a72eaa210b579L83-R84) [[2]](diffhunk://#diff-3295dc7dde885bb67176d1514b95de33527c6cdf6c2050de8c3a72eaa210b579L156-R141) [[3]](diffhunk://#diff-94476811220a0bc0ea1f4821363c8493ed621a5541b50ecf9f49367022e7f177R1-R12)

**Testing:**
* Added `urbantrips/tests/unit/test_cli.py` with tests for both argument parsing and environment variable propagation, covering all expected flag combinations and edge cases.

**Documentation and Usage:**
* Added a new design spec `docs/superpowers/specs/2026-07-02-unify-cli-bootstrap-args-design.md` detailing the motivation, architecture, and usage of the unified CLI approach.
* Updated usage examples in `README.md` and `README_en.md` to reflect support for `--base-dir` and the new consistent CLI interface. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R341-R342) [[2]](diffhunk://#diff-4f212053d7c510c6df117a36fa56a4dbacb596e78b0d0d0b5e678a61c8561c19R341-R342)